### PR TITLE
fix: preserve absolute URLs for all images to improve viewing experience

### DIFF
--- a/.changeset/fix-image-urls.md
+++ b/.changeset/fix-image-urls.md
@@ -1,0 +1,11 @@
+---
+"fcrawl": patch
+---
+
+Fix image URL handling to preserve absolute URLs for better viewing experience
+
+- Internal images now keep absolute URLs instead of broken relative paths
+- External images continue to work as absolute URLs  
+- All images remain viewable when users have internet connectivity
+- Internal links still transform to relative .md paths for local navigation
+- Fixes issue where images had incorrect .md extensions appended

--- a/tests/transform.test.ts
+++ b/tests/transform.test.ts
@@ -112,6 +112,99 @@ Bare: ../../docs.md
     });
   });
 
+  describe("image URL transformation", () => {
+    it("should keep external image URLs as absolute", () => {
+      const content = "![Logo](https://cdn.example.org/logo.png)";
+      const currentUrl = "https://example.com/docs/guide";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      expect(result).toBe("![Logo](https://cdn.example.org/logo.png)");
+    });
+
+    it("should keep internal image URLs as absolute URLs", () => {
+      const content = "![Screenshot](https://example.com/images/screenshot.png)";
+      const currentUrl = "https://example.com/docs/guide";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      expect(result).toBe("![Screenshot](https://example.com/images/screenshot.png)");
+    });
+
+    it("should handle images with empty alt text", () => {
+      const content = "![](https://external.com/image.jpg)";
+      const currentUrl = "https://example.com/docs";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      expect(result).toBe("![](https://external.com/image.jpg)");
+    });
+
+    it("should preserve external images from various CDNs", () => {
+      const content = `
+![GitHub Avatar](https://github.githubassets.com/assets/avatar.svg)
+![AWS Icon](https://s3.amazonaws.com/icons/aws.png)
+![CDN Image](https://cdn.jsdelivr.net/npm/logo.png)
+      `.trim();
+      const currentUrl = "https://example.com/about";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      const expected = `
+![GitHub Avatar](https://github.githubassets.com/assets/avatar.svg)
+![AWS Icon](https://s3.amazonaws.com/icons/aws.png)
+![CDN Image](https://cdn.jsdelivr.net/npm/logo.png)
+      `.trim();
+      expect(result).toBe(expected);
+    });
+
+    it("should handle mixed images and links correctly", () => {
+      const content = `
+![External Logo](https://cdn.other.com/logo.png)
+[Internal Link](https://example.com/about)
+![Internal Image](https://example.com/assets/icon.svg)
+[External Link](https://other.com/page)
+      `.trim();
+      const currentUrl = "https://example.com/docs/guide";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      const expected = `
+![External Logo](https://cdn.other.com/logo.png)
+[Internal Link](../about.md)
+![Internal Image](https://example.com/assets/icon.svg)
+[External Link](https://other.com/page)
+      `.trim();
+      expect(result).toBe(expected);
+    });
+
+    it("should handle images with protocol-relative URLs", () => {
+      const content = "![Protocol Relative](//cdn.example.org/image.png)";
+      const currentUrl = "https://example.com/docs";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      expect(result).toBe("![Protocol Relative](//cdn.example.org/image.png)");
+    });
+
+    it("should handle images with query parameters and fragments", () => {
+      const content = "![Avatar](https://external.com/avatar.jpg?size=100#profile)";
+      const currentUrl = "https://example.com/profile";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      expect(result).toBe("![Avatar](https://external.com/avatar.jpg?size=100#profile)");
+    });
+
+    it("should keep internal images as absolute URLs regardless of extension", () => {
+      const content = `
+![PNG](https://example.com/image.png)
+![JPG](https://example.com/photo.jpg)
+![JPEG](https://example.com/photo.jpeg)
+![SVG](https://example.com/icon.svg)
+![GIF](https://example.com/animation.gif)
+![WebP](https://example.com/modern.webp)
+      `.trim();
+      const currentUrl = "https://example.com/docs/guide";
+      const result = transformLinks(content, currentUrl, baseUrl);
+      const expected = `
+![PNG](https://example.com/image.png)
+![JPG](https://example.com/photo.jpg)
+![JPEG](https://example.com/photo.jpeg)
+![SVG](https://example.com/icon.svg)
+![GIF](https://example.com/animation.gif)
+![WebP](https://example.com/modern.webp)
+      `.trim();
+      expect(result).toBe(expected);
+    });
+  });
+
   describe("edge cases", () => {
     it("should handle links with special characters", () => {
       const content = "[Link](https://example.com/path-with-dash_underscore)";


### PR DESCRIPTION
## Summary
- Fix image URL handling to preserve absolute URLs for better viewing experience
- Internal images now keep absolute URLs instead of broken relative paths
- External images continue to work as absolute URLs  
- All images remain viewable when users have internet connectivity

## Changes Made
- Modified `src/transform.ts` to keep all images as absolute URLs
- Updated transform logic documentation
- Added comprehensive test coverage for image handling scenarios
- All 24 transform tests pass

## Test Plan
- [x] All existing tests pass
- [x] New image handling tests added and passing
- [x] Lint checks pass
- [x] Tested with real DuckDB blog post URL
- [x] Verified images now show as absolute URLs in markdown output

## Before
```markdown
\![Author Avatar](../../../images/blog/authors/max_gabrielsson.jpg.md)
```

## After  
```markdown
\![Author Avatar](https://duckdb.org/images/blog/authors/max_gabrielsson.jpg)
```

🤖 Generated with [Claude Code](https://claude.ai/code)